### PR TITLE
add ember id to input for token blocks

### DIFF
--- a/client/app/pods/block-tokens/component.js
+++ b/client/app/pods/block-tokens/component.js
@@ -48,7 +48,9 @@ export default Ember.Component.extend(FocusEntryAction, {
         });
       }
     });
-
+    
+    this.$('ul.tagit input').attr('id', Ember.guidFor(this.get('entry')));
+    
     this.$('ul.tagit input').on('focus', () => {
       this.$('ul.tagit').addClass('tagit-focus');
     });


### PR DESCRIPTION
This fixes the unlabeled form element in the keyword token blocks